### PR TITLE
Filter out more MIMEtypes.

### DIFF
--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -217,7 +217,7 @@
                handle the mimetypes supported by the "getDatastreamText" call:
                https://github.com/fcrepo/gsearch/blob/master/FedoraGenericSearch/src/java/dk/defxws/fedoragsearch/server/TransformerToText.java#L185-L200
           -->
-          <xsl:when test="@CONTROL_GROUP='M' and foxml:datastreamVersion[last() and not(starts-with(@MIMETYPE, 'image'))]">
+          <xsl:when test="@CONTROL_GROUP='M' and foxml:datastreamVersion[last() and not(starts-with(@MIMETYPE, 'image') or starts-with(@MIMETYPE, 'audio') or starts-with(@MIMETYPE, 'video'))]">
             <!-- TODO: should do something about mime type filtering
               text/plain should use the getDatastreamText extension because document will only work for xml docs
               xml files should use the document function


### PR DESCRIPTION
The SOAP call getDatastreamText uses behind the scenes can blow up
with large datastreams... What exactly the threshold is, I don't know...
...  in our case, it was a > 100 MB wav file.
