### PR TITLE
Rewrite RELS-EXT to be more templatey and create fields copies with more specific names.

### DIFF
--- a/islandora_transforms/RELS-EXT_to_solr.xslt
+++ b/islandora_transforms/RELS-EXT_to_solr.xslt
@@ -13,75 +13,95 @@
         <xsl:param name="prefix">RELS_EXT_</xsl:param>
         <xsl:param name="suffix">_ms</xsl:param>
 
-        <xsl:for-each
-            select="$content//rdf:Description/*[@rdf:resource] | $content//rdf:description/*[@rdf:resource]">
-            <!-- Prevent multiple generating multiple instances of single-valued fields
-            by tracking things in a HashSet -->
-            <!-- The method java.util.HashSet.add will return false when the value is
-            already in the set. -->
-            <xsl:choose>
-                <xsl:when
-                    test="java:add($single_valued_hashset_for_rels_ext, concat($prefix, local-name(), '_uri_s'))">
-                    <field>
-                        <xsl:attribute name="name">
-                            <xsl:value-of select="concat($prefix, local-name(), '_uri_s')"/>
-                        </xsl:attribute>
-                        <xsl:value-of select="@rdf:resource"/>
-                    </field>
-                    <xsl:if test="@rdf:datatype = 'http://www.w3.org/2001/XMLSchema#int'">
-                        <field>
-                            <xsl:attribute name="name">
-                                <xsl:value-of select="concat($prefix, local-name(), '_uri_l')"/>
-                            </xsl:attribute>
-                            <xsl:value-of select="@rdf:resource"/>
-                        </field>
-                    </xsl:if>
-                </xsl:when>
-                <xsl:otherwise>
-                    <field>
-                        <xsl:attribute name="name">
-                            <xsl:value-of select="concat($prefix, local-name(), '_uri', $suffix)"/>
-                        </xsl:attribute>
-                        <xsl:value-of select="@rdf:resource"/>
-                    </field>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:for-each>
-        <xsl:for-each
-            select="$content//rdf:Description/*[not(@rdf:resource)][normalize-space(text())] | $content//rdf:description/*[not(@rdf:resource)][normalize-space(text())]">
-            <!-- Prevent multiple generating multiple instances of single-valued fields
-            by tracking things in a HashSet -->
-            <!-- The method java.util.HashSet.add will return false when the value is
-            already in the set. -->
-            <xsl:choose>
-                <xsl:when
-                    test="java:add($single_valued_hashset_for_rels_ext, concat($prefix, local-name(), '_literal_s'))">
-                    <field>
-                        <xsl:attribute name="name">
-                            <xsl:value-of select="concat($prefix, local-name(), '_literal_s')"/>
-                        </xsl:attribute>
-                        <xsl:value-of select="text()"/>
-                    </field>
-                    <xsl:if test="@rdf:datatype = 'http://www.w3.org/2001/XMLSchema#int'">
-                        <field>
-                            <xsl:attribute name="name">
-                                <xsl:value-of select="concat($prefix, local-name(), '_literal_l')"/>
-                            </xsl:attribute>
-                            <xsl:value-of select="text()"/>
-                        </field>
-                    </xsl:if>
-                </xsl:when>
-                <xsl:otherwise>
-                    <field>
-                        <xsl:attribute name="name">
-                            <xsl:value-of
-                                select="concat($prefix, local-name(), '_literal', $suffix)"/>
-                        </xsl:attribute>
-                        <xsl:value-of select="text()"/>
-                    </field>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:for-each>
+        <xsl:apply-templates select="$content//rdf:Description/* | $content//rdf:description/*" mode="rels_ext_element">
+          <xsl:with-param name="prefix" select="$prefix"/>
+          <xsl:with-param name="suffix" select="$suffix"/>
+        </xsl:apply-templates>
     </xsl:template>
 
+    <!-- Match elements, call underlying template. -->
+    <xsl:template match="*[@rdf:resource]" mode="rels_ext_element">
+      <xsl:param name="prefix"/>
+      <xsl:param name="suffix"/>
+
+      <xsl:call-template name="rels_ext_fields">
+        <xsl:with-param name="prefix" select="$prefix"/>
+        <xsl:with-param name="suffix" select="$suffix"/>
+        <xsl:with-param name="type">uri</xsl:with-param>
+        <xsl:with-param name="value" select="@rdf:resource"/>
+      </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="*[normalize-space(.)]" mode="rels_ext_element">
+      <xsl:param name="prefix"/>
+      <xsl:param name="suffix"/>
+
+      <xsl:call-template name="rels_ext_fields">
+        <xsl:with-param name="prefix" select="$prefix"/>
+        <xsl:with-param name="suffix" select="$suffix"/>
+        <xsl:with-param name="type">literal</xsl:with-param>
+        <xsl:with-param name="value" select="text()"/>
+      </xsl:call-template>
+    </xsl:template>
+
+    <!-- Fork between fields without and with the namespace URI in the field
+      name. -->
+    <xsl:template name="rels_ext_fields">
+      <xsl:param name="prefix"/>
+      <xsl:param name="suffix"/>
+      <xsl:param name="type"/>
+      <xsl:param name="value"/>
+
+      <xsl:call-template name="rels_ext_field">
+        <xsl:with-param name="prefix" select="$prefix"/>
+        <xsl:with-param name="suffix" select="$suffix"/>
+        <xsl:with-param name="type" select="$type"/>
+        <xsl:with-param name="value" select="$value"/>
+      </xsl:call-template>
+      <xsl:call-template name="rels_ext_field">
+        <xsl:with-param name="prefix" select="concat($prefix, namespace-uri())"/>
+        <xsl:with-param name="suffix" select="$suffix"/>
+        <xsl:with-param name="type" select="$type"/>
+        <xsl:with-param name="value" select="$value"/>
+      </xsl:call-template>
+    </xsl:template>
+
+    <!-- Actually create a field. -->
+    <xsl:template name="rels_ext_field">
+      <xsl:param name="prefix"/>
+      <xsl:param name="suffix"/>
+      <xsl:param name="type"/>
+      <xsl:param name="value"/>
+
+      <!-- Prevent multiple generating multiple instances of single-valued fields
+      by tracking things in a HashSet -->
+      <!-- The method java.util.HashSet.add will return false when the value is
+      already in the set. -->
+      <xsl:choose>
+        <xsl:when
+          test="java:add($single_valued_hashset_for_rels_ext, concat($prefix, local-name(), '_', $type, '_s'))">
+          <field>
+            <xsl:attribute name="name">
+              <xsl:value-of select="concat($prefix, local-name(), '_', $type, '_s')"/>
+            </xsl:attribute>
+            <xsl:value-of select="$value"/>
+          </field>
+          <xsl:if test="@rdf:datatype = 'http://www.w3.org/2001/XMLSchema#int'">
+            <field>
+              <xsl:attribute name="name">
+                <xsl:value-of select="concat($prefix, local-name(), '_', $type, '_l')"/>
+              </xsl:attribute>
+              <xsl:value-of select="$value"/>
+            </field>
+          </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+          <field>
+            <xsl:attribute name="name">
+              <xsl:value-of select="concat($prefix, local-name(), '_', $type, $suffix)"/>
+            </xsl:attribute>
+            <xsl:value-of select="$value"/>
+          </field>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
RELS-INT could use a similar approach; though, would want to deal with "todo" concerning having the datastream ID in the field name.

"More specific names", meaning that they include the full namespace URI... May encounter places where escaping is an issue, but we'll deal with 'em as we come to them.
